### PR TITLE
Make mathjax render on preview (and all changes)

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -159,6 +159,8 @@ function renderMathJax3( equation, element, display, cb ) {
 				element.removeChild( element.firstChild );
 			}
 			element.appendChild( node );
+			MathJax.startup.document.clear();
+			MathJax.startup.document.updateDocument();
 			cb();
 		} );
 	}


### PR DESCRIPTION
In a previous refactor re-triggering mathjax was removed.
This unfortunately means when previewing a formula the rendered view is
not updated and looks incorrect. Putting the calls to Mathjax in after
rendering fixes this.