### PR TITLE
Change 'Display mode' label

### DIFF
--- a/src/ui/mainformview.js
+++ b/src/ui/mainformview.js
@@ -221,7 +221,7 @@ export default class MainFormView extends View {
 		const switchButton = new SwitchButtonView( this.locale );
 
 		switchButton.set( {
-			label: t( 'Display mode' ),
+			label: t( 'Show on own line' ),
 			withText: true
 		} );
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/y3tFZQDE)

While testing the math plugin it was apparent that the current label is not descriptive enough. Simply enabling or disabling the 'Display mode' did not suggest the users that it would actually display the math formula on its own line with proper spacing, or inline with the rest of the text. This commit aims to improve the user experience by changing the title to more descriptive one

## Feedback
- is there any better title?
- is there anything else that could be implemented here to improve the UI

## UI Changes

Show on own line enabled

https://user-images.githubusercontent.com/8191039/154299463-d142b113-4161-4ae8-b0f9-6995f7204058.mov

Show on own line disabled


https://user-images.githubusercontent.com/8191039/154301440-da177622-56db-4b5e-bb6b-af9f310b1a61.mov

